### PR TITLE
Implement game start flow

### DIFF
--- a/lib/live_checkers/application.ex
+++ b/lib/live_checkers/application.ex
@@ -17,6 +17,7 @@ defmodule LiveCheckers.Application do
       # {LiveCheckers.Worker, arg},
       # Start to serve requests, typically the last entry
       LiveCheckersWeb.Endpoint,
+      LiveCheckers.Game.GameSupervisor,
       LiveCheckers.Game.LobbyManager
     ]
 

--- a/lib/live_checkers/game/game_supervisor.ex
+++ b/lib/live_checkers/game/game_supervisor.ex
@@ -1,0 +1,29 @@
+defmodule LiveCheckers.Game.GameSupervisor do
+  @moduledoc """
+  Dynamic supervisor responsible for running `CheckersGame` processes.
+  """
+  use DynamicSupervisor
+
+  alias LiveCheckers.Game.CheckersGame
+
+  ## Public API
+
+  @doc "Starts the supervisor"
+  def start_link(init_arg \\ :ok) do
+    DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @doc "Starts a new game under the supervisor"
+  def start_game(game_id, players) do
+    child_spec = {CheckersGame, {game_id, players}}
+    DynamicSupervisor.start_child(__MODULE__, child_spec)
+  end
+
+  ## Callbacks
+
+  @impl true
+  def init(:ok) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end
+

--- a/lib/live_checkers/game/lobby_manager.ex
+++ b/lib/live_checkers/game/lobby_manager.ex
@@ -171,7 +171,7 @@ defmodule LiveCheckers.Game.LobbyManager do
         if Map.has_key?(lobby, :game_pid) do
           {:reply, {:error, :already_started}, state}
         else
-          {:ok, pid} = LiveCheckers.Game.CheckersGame.start_link({lobby_id, Enum.reverse(lobby.players)})
+          {:ok, pid} = LiveCheckers.Game.GameSupervisor.start_game(lobby_id, Enum.reverse(lobby.players))
           updated_lobby = Map.put(lobby, :game_pid, pid)
           new_lobbies = Map.put(state.lobbies, lobby_id, updated_lobby)
           {:reply, {:ok, updated_lobby}, %{state | lobbies: new_lobbies}}

--- a/lib/live_checkers_web/live/components/lobby_detail_component.ex
+++ b/lib/live_checkers_web/live/components/lobby_detail_component.ex
@@ -33,7 +33,7 @@ defmodule LiveCheckersWeb.LobbyDetailComponent do
           <p class="text-green-500 font-bold mb-4">Game ready to start!</p>
           <%= if @lobby.creator == @username do %>
             <button
-              phx-click="start-game"
+              phx-click="start_game"
               phx-target={@myself}
               class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
             >
@@ -53,7 +53,7 @@ defmodule LiveCheckersWeb.LobbyDetailComponent do
     {:noreply, socket}
   end
 
-  def handle_event("start-game", _, socket) do
+  def handle_event("start_game", _, socket) do
     send(self(), {:start_game, socket.assigns.lobby.id})
     {:noreply, socket}
   end

--- a/lib/live_checkers_web/live/game_live.ex
+++ b/lib/live_checkers_web/live/game_live.ex
@@ -1,0 +1,32 @@
+defmodule LiveCheckersWeb.GameLive do
+  use LiveCheckersWeb, :live_view
+
+  alias LiveCheckers.Game.CheckersGame
+
+  @impl true
+  def mount(%{"id" => game_id}, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(LiveCheckers.PubSub, "game:" <> game_id)
+    end
+
+    state = CheckersGame.current_state(game_id)
+
+    {:ok, assign(socket, game_id: game_id, state: state)}
+  end
+
+  @impl true
+  def handle_info({:state_changed, state}, socket) do
+    {:noreply, assign(socket, state: state)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="container mx-auto p-4">
+      <h1 class="text-xl font-bold mb-4">Game <%= @game_id %></h1>
+      <pre><%= inspect(@state, pretty: true) %></pre>
+    </div>
+    """
+  end
+end
+

--- a/lib/live_checkers_web/live/lobby_live.ex
+++ b/lib/live_checkers_web/live/lobby_live.ex
@@ -139,7 +139,10 @@ defmodule LiveCheckersWeb.LobbyLive do
     case LobbyManager.start_game(lobby_id) do
       {:ok, lobby} ->
         broadcast_lobby_update()
-        {:noreply, assign(socket, current_lobby: lobby, error_message: nil)}
+        {:noreply,
+         socket
+         |> assign(current_lobby: lobby, error_message: nil)
+         |> push_redirect(to: ~p"/game/#{lobby.id}")}
 
       {:error, reason} ->
         {:noreply, assign(socket, error_message: "Error starting game: #{reason}")}
@@ -160,7 +163,13 @@ defmodule LiveCheckersWeb.LobbyLive do
             # Lobby no longer exists, go back to list
             assign(socket, page: :lobby_list)
           updated_lobby ->
-            assign(socket, current_lobby: updated_lobby)
+            if Map.has_key?(updated_lobby, :game_pid) do
+              socket
+              |> assign(current_lobby: updated_lobby)
+              |> push_redirect(to: ~p"/game/#{updated_lobby.id}")
+            else
+              assign(socket, current_lobby: updated_lobby)
+            end
         end
       else
         socket

--- a/lib/live_checkers_web/router.ex
+++ b/lib/live_checkers_web/router.ex
@@ -19,6 +19,7 @@ defmodule LiveCheckersWeb.Router do
 
     get "/", PageController, :home
     live "/lobby", LobbyLive, :index
+    live "/game/:id", GameLive, :show
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
## Summary
- add `GameSupervisor` for dynamic game processes
- route and LiveView for showing games
- update lobby detail events
- redirect players to game when it starts
- supervise game processes

## Testing
- `mix test` *(fails: mix not found)*