### PR TITLE
Add interactive game board

### DIFF
--- a/lib/live_checkers/game/checkers_game.ex
+++ b/lib/live_checkers/game/checkers_game.ex
@@ -125,10 +125,10 @@ defmodule LiveCheckers.Game.CheckersGame do
   end
 
   defp initial_board do
-    for row <- 0..7, col <- 0..7, into: %{} do
+    for row <- 0..9, col <- 0..9, into: %{} do
       cond do
-        row < 3 and rem(row + col, 2) == 1 -> {{row, col}, {:black, :man}}
-        row > 4 and rem(row + col, 2) == 1 -> {{row, col}, {:red, :man}}
+        row < 4 and rem(row + col, 2) == 1 -> {{row, col}, {:black, :man}}
+        row > 5 and rem(row + col, 2) == 1 -> {{row, col}, {:red, :man}}
         true -> {{row, col}, nil}
       end
     end

--- a/lib/live_checkers/game/rules.ex
+++ b/lib/live_checkers/game/rules.ex
@@ -5,7 +5,7 @@ defmodule LiveCheckers.Game.Rules do
   `{color, type}` tuples or `nil` when the square is empty.
   """
 
-  @board_range 0..7
+  @board_range 0..9
 
   @type color :: :black | :red
   @type piece_type :: :man | :king
@@ -17,10 +17,10 @@ defmodule LiveCheckers.Game.Rules do
   @doc "Returns the initial board setup for a game of checkers."
   @spec initial_board() :: board()
   def initial_board do
-    for row <- 0..7, col <- 0..7, into: %{} do
+    for row <- 0..9, col <- 0..9, into: %{} do
       cond do
-        row < 3 and rem(row + col, 2) == 1 -> {{row, col}, {:black, :man}}
-        row > 4 and rem(row + col, 2) == 1 -> {{row, col}, {:red, :man}}
+        row < 4 and rem(row + col, 2) == 1 -> {{row, col}, {:black, :man}}
+        row > 5 and rem(row + col, 2) == 1 -> {{row, col}, {:red, :man}}
         true -> {{row, col}, nil}
       end
     end
@@ -112,7 +112,7 @@ defmodule LiveCheckers.Game.Rules do
 
   defp maybe_promote({color, :man}, {row, _}) do
     cond do
-      color == :black and row == 7 -> {color, :king}
+      color == :black and row == 9 -> {color, :king}
       color == :red and row == 0 -> {color, :king}
       true -> {color, :man}
     end

--- a/lib/live_checkers_web/live/components/board_component.ex
+++ b/lib/live_checkers_web/live/components/board_component.ex
@@ -1,0 +1,53 @@
+defmodule LiveCheckersWeb.BoardComponent do
+  use LiveCheckersWeb, :html
+
+  attr :board, :map, required: true
+  attr :selected, :any, default: nil
+
+  def board(assigns) do
+    ~H"""
+    <div class="grid grid-cols-10 gap-0">
+      <%= for row <- 0..9 do %>
+        <%= for col <- 0..9 do %>
+          <% piece = Map.get(@board, {row, col}) %>
+          <div
+            id={"square-#{row}-#{col}"}
+            phx-click="square_click"
+            phx-value-row={row}
+            phx-value-col={col}
+            class={square_classes(row, col, @selected)}
+          >
+            <%= case piece do %>
+              <% nil -> %>
+                
+              <% {:black, :man} -> %>
+                <span class="text-black">●</span>
+              <% {:red, :man} -> %>
+                <span class="text-red-600">●</span>
+              <% {:black, :king} -> %>
+                <span class="font-bold text-black">K</span>
+              <% {:red, :king} -> %>
+                <span class="font-bold text-red-600">K</span>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+    """
+  end
+
+  defp square_classes(row, col, selected) do
+    base =
+      if rem(row + col, 2) == 0 do
+        "w-8 h-8 flex items-center justify-center bg-gray-200"
+      else
+        "w-8 h-8 flex items-center justify-center bg-gray-700 text-white"
+      end
+
+    if selected == {row, col} do
+      base <> " border-2 border-yellow-400"
+    else
+      base
+    end
+  end
+end

--- a/lib/live_checkers_web/live/game_live.ex
+++ b/lib/live_checkers_web/live/game_live.ex
@@ -2,6 +2,7 @@ defmodule LiveCheckersWeb.GameLive do
   use LiveCheckersWeb, :live_view
 
   alias LiveCheckers.Game.CheckersGame
+  alias LiveCheckersWeb.BoardComponent
 
   @impl true
   def mount(%{"id" => game_id}, _session, socket) do
@@ -11,7 +12,7 @@ defmodule LiveCheckersWeb.GameLive do
 
     state = CheckersGame.current_state(game_id)
 
-    {:ok, assign(socket, game_id: game_id, state: state)}
+    {:ok, assign(socket, game_id: game_id, state: state, selected: nil)}
   end
 
   @impl true
@@ -20,11 +21,25 @@ defmodule LiveCheckersWeb.GameLive do
   end
 
   @impl true
+  def handle_event("square_click", %{"row" => row, "col" => col}, socket) do
+    pos = {String.to_integer(row), String.to_integer(col)}
+
+    case socket.assigns.selected do
+      nil ->
+        {:noreply, assign(socket, selected: pos)}
+
+      from ->
+        CheckersGame.apply_move(socket.assigns.game_id, {from, pos})
+        {:noreply, assign(socket, selected: nil)}
+    end
+  end
+
+  @impl true
   def render(assigns) do
     ~H"""
     <div class="container mx-auto p-4">
       <h1 class="text-xl font-bold mb-4">Game <%= @game_id %></h1>
-      <pre><%= inspect(@state, pretty: true) %></pre>
+      <BoardComponent.board board={@state.board} selected={@selected} />
     </div>
     """
   end

--- a/test/live_checkers/game/rules_test.exs
+++ b/test/live_checkers/game/rules_test.exs
@@ -4,7 +4,7 @@ defmodule LiveCheckers.Game.RulesTest do
   alias LiveCheckers.Game.Rules
 
   defp empty_board do
-    for r <- 0..7, c <- 0..7, into: %{}, do: {{r, c}, nil}
+    for r <- 0..9, c <- 0..9, into: %{}, do: {{r, c}, nil}
   end
 
   describe "legal_moves/2" do
@@ -13,11 +13,11 @@ defmodule LiveCheckers.Game.RulesTest do
 
       moves_black = Rules.legal_moves(board, :black)
       assert {{2, 1}, {3, 0}} in moves_black
-      assert length(moves_black) == 7
+      assert length(moves_black) == 10
 
       moves_red = Rules.legal_moves(board, :red)
-      assert {{5, 0}, {4, 1}} in moves_red
-      assert length(moves_red) == 7
+      assert {{6, 1}, {5, 0}} in moves_red
+      assert length(moves_red) == 10
     end
   end
 
@@ -46,12 +46,12 @@ defmodule LiveCheckers.Game.RulesTest do
 
     test "moving to last row promotes" do
       board = empty_board()
-      board = Map.put(board, {6, 1}, {:black, :man})
+      board = Map.put(board, {8, 1}, {:black, :man})
 
-      assert Rules.valid_move?(board, :black, {6, 1}, {7, 0})
-      board = Rules.update_board(board, {{6, 1}, {7, 0}})
+      assert Rules.valid_move?(board, :black, {8, 1}, {9, 0})
+      board = Rules.update_board(board, {{8, 1}, {9, 0}})
 
-      assert Map.get(board, {7, 0}) == {:black, :king}
+      assert Map.get(board, {9, 0}) == {:black, :king}
     end
   end
 end


### PR DESCRIPTION
## Summary
- implement 10×10 board in rules and game logic
- add `BoardComponent` to render board squares
- update `GameLive` to use board component and handle moves
- adjust tests for new board size

## Testing
- `mix test` *(fails: mix not available)*