### PR TITLE
Add board highlights and presence

### DIFF
--- a/lib/live_checkers/application.ex
+++ b/lib/live_checkers/application.ex
@@ -11,6 +11,7 @@ defmodule LiveCheckers.Application do
       LiveCheckersWeb.Telemetry,
       {DNSCluster, query: Application.get_env(:live_checkers, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: LiveCheckers.PubSub},
+      LiveCheckersWeb.Presence,
       # Start the Finch HTTP client for sending emails
       {Finch, name: LiveCheckers.Finch},
       # Start a worker by calling: LiveCheckers.Worker.start_link(arg)

--- a/lib/live_checkers_web/live/components/board_component.ex
+++ b/lib/live_checkers_web/live/components/board_component.ex
@@ -3,6 +3,8 @@ defmodule LiveCheckersWeb.BoardComponent do
 
   attr :board, :map, required: true
   attr :selected, :any, default: nil
+  attr :valid_moves, :list, default: []
+  attr :capture_paths, :list, default: []
 
   def board(assigns) do
     ~H"""
@@ -15,11 +17,11 @@ defmodule LiveCheckersWeb.BoardComponent do
             phx-click="square_click"
             phx-value-row={row}
             phx-value-col={col}
-            class={square_classes(row, col, @selected)}
+            class={square_classes(row, col, @selected, @valid_moves, @capture_paths)}
           >
             <%= case piece do %>
               <% nil -> %>
-                
+
               <% {:black, :man} -> %>
                 <span class="text-black">●</span>
               <% {:red, :man} -> %>
@@ -36,7 +38,7 @@ defmodule LiveCheckersWeb.BoardComponent do
     """
   end
 
-  defp square_classes(row, col, selected) do
+  defp square_classes(row, col, selected, valid_moves, capture_paths) do
     base =
       if rem(row + col, 2) == 0 do
         "w-8 h-8 flex items-center justify-center bg-gray-200"
@@ -44,10 +46,10 @@ defmodule LiveCheckersWeb.BoardComponent do
         "w-8 h-8 flex items-center justify-center bg-gray-700 text-white"
       end
 
-    if selected == {row, col} do
-      base <> " border-2 border-yellow-400"
-    else
-      base
-    end
+    move_highlight = if {row, col} in valid_moves, do: " border-2 border-green-400", else: ""
+    capture_highlight = if {row, col} in capture_paths, do: " bg-red-500", else: ""
+    selected_highlight = if selected == {row, col}, do: " border-2 border-yellow-400", else: ""
+
+    base <> move_highlight <> capture_highlight <> selected_highlight
   end
 end

--- a/lib/live_checkers_web/live/game_live.ex
+++ b/lib/live_checkers_web/live/game_live.ex
@@ -2,17 +2,28 @@ defmodule LiveCheckersWeb.GameLive do
   use LiveCheckersWeb, :live_view
 
   alias LiveCheckers.Game.CheckersGame
-  alias LiveCheckersWeb.BoardComponent
+  alias LiveCheckers.Game.Rules
+  alias LiveCheckersWeb.{BoardComponent, Presence}
 
   @impl true
   def mount(%{"id" => game_id}, _session, socket) do
     if connected?(socket) do
       Phoenix.PubSub.subscribe(LiveCheckers.PubSub, "game:" <> game_id)
+      Presence.track(self(), "game:" <> game_id, socket.id, %{})
     end
 
     state = CheckersGame.current_state(game_id)
+    watchers = Presence.list("game:" <> game_id) |> map_size()
 
-    {:ok, assign(socket, game_id: game_id, state: state, selected: nil)}
+    {:ok,
+     assign(socket,
+       game_id: game_id,
+       state: state,
+       selected: nil,
+       valid_moves: [],
+       capture_paths: [],
+       watchers: watchers
+     )}
   end
 
   @impl true
@@ -21,16 +32,45 @@ defmodule LiveCheckersWeb.GameLive do
   end
 
   @impl true
+  def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff"}, socket) do
+    watchers = Presence.list("game:" <> socket.assigns.game_id) |> map_size()
+    {:noreply, assign(socket, watchers: watchers)}
+  end
+
+  @impl true
   def handle_event("square_click", %{"row" => row, "col" => col}, socket) do
     pos = {String.to_integer(row), String.to_integer(col)}
 
     case socket.assigns.selected do
       nil ->
-        {:noreply, assign(socket, selected: pos)}
+        moves =
+          case Map.get(socket.assigns.state.board, pos) do
+            {color, _} ->
+              Rules.legal_moves(socket.assigns.state.board, color)
+              |> Enum.filter(fn {from, _} -> from == pos end)
+            _ ->
+              []
+          end
+
+        valid = Enum.map(moves, fn {_f, to} -> to end)
+        capture_paths =
+          Enum.filter(moves, fn {from, to} -> abs(elem(from, 0) - elem(to, 0)) == 2 end)
+          |> Enum.map(fn {from, to} -> {div(elem(from, 0) + elem(to, 0), 2), div(elem(from, 1) + elem(to, 1), 2)} end)
+        {:noreply,
+         assign(socket,
+           selected: pos,
+           valid_moves: valid,
+           capture_paths: capture_paths
+         )}
 
       from ->
         CheckersGame.apply_move(socket.assigns.game_id, {from, pos})
-        {:noreply, assign(socket, selected: nil)}
+        {:noreply,
+         assign(socket,
+           selected: nil,
+           valid_moves: [],
+           capture_paths: []
+         )}
     end
   end
 
@@ -39,7 +79,13 @@ defmodule LiveCheckersWeb.GameLive do
     ~H"""
     <div class="container mx-auto p-4">
       <h1 class="text-xl font-bold mb-4">Game <%= @game_id %></h1>
-      <BoardComponent.board board={@state.board} selected={@selected} />
+      <div class="mb-2 text-sm text-gray-600">Spectators: <%= @watchers %></div>
+      <BoardComponent.board
+        board={@state.board}
+        selected={@selected}
+        valid_moves={@valid_moves}
+        capture_paths={@capture_paths}
+      />
       <%= if @state.status == :game_over do %>
         <div class="mt-4 p-4 bg-green-100 border border-green-400 rounded">
           <%= if @state.winner do %>

--- a/lib/live_checkers_web/presence.ex
+++ b/lib/live_checkers_web/presence.ex
@@ -1,0 +1,5 @@
+defmodule LiveCheckersWeb.Presence do
+  use Phoenix.Presence,
+    otp_app: :live_checkers,
+    pubsub_server: LiveCheckers.PubSub
+end


### PR DESCRIPTION
## Summary
- highlight legal moves and capture paths on the board
- display spectators count and track via Phoenix Presence

## Testing
- `mix format` *(fails: `mix: command not found`)*
- `mix test` *(fails: `mix: command not found`)*