### PR TITLE
Fix compile warnings

### DIFF
--- a/lib/live_checkers/game/checkers_game.ex
+++ b/lib/live_checkers/game/checkers_game.ex
@@ -28,7 +28,7 @@ defmodule LiveCheckers.Game.CheckersGame do
   end
 
   @doc "Applies a move described by `{from, to}` coordinates." 
-  def apply_move(game_id, {from, to} = move) do
+  def apply_move(game_id, move) do
     GenServer.call(game_name(game_id), {:apply_move, move})
   end
 
@@ -59,7 +59,7 @@ defmodule LiveCheckers.Game.CheckersGame do
     {:reply, state, state}
   end
 
-  def handle_call({:apply_move, {from, to}}, _from, %{status: :game_over} = state) do
+  def handle_call({:apply_move, {_from, _to}}, _from, %{status: :game_over} = state) do
     {:reply, {:error, :game_over}, state}
   end
 

--- a/lib/live_checkers/game/lobby_manager.ex
+++ b/lib/live_checkers/game/lobby_manager.ex
@@ -165,7 +165,7 @@ defmodule LiveCheckers.Game.LobbyManager do
       nil ->
         {:reply, {:error, :not_found}, state}
 
-      %{players: players} = lobby when length(players) < 2 ->
+      %{players: players} when length(players) < 2 ->
         {:reply, {:error, :not_enough_players}, state}
 
       lobby ->

--- a/lib/live_checkers/game/rules.ex
+++ b/lib/live_checkers/game/rules.ex
@@ -82,9 +82,10 @@ defmodule LiveCheckers.Game.Rules do
 
       capture_dest = {row + 2 * dr, col + 2 * dc}
       between = {row + dr, col + dc}
+      opp_color = other_color(color)
       capture_moves =
         if inside_board?(capture_dest) &&
-             match?({other_color(color), _}, Map.get(board, between)) &&
+             match?({^opp_color, _}, Map.get(board, between)) &&
              Map.get(board, capture_dest) == nil do
           [{from, capture_dest}]
         else


### PR DESCRIPTION
## Summary
- remove unused variables in LobbyManager and CheckersGame
- use runtime variable when checking captured pieces in `Rules.piece_moves`

## Testing
- `mix format` *(fails: `mix: command not found`)*